### PR TITLE
Jenkins CI

### DIFF
--- a/jenkinsci/Dockerfile
+++ b/jenkinsci/Dockerfile
@@ -1,0 +1,27 @@
+# "ported" by Adam Miller <maxamillion@fedoraproject.org> from
+#   https://github.com/fedora-cloud/Fedora-Dockerfiles
+#
+# Originally written for Fedora-Dockerfiles by
+#   scollier <scollier@redhat.com>
+
+FROM centos:centos7
+MAINTAINER The CentOS Project <cloud-ops@centos.org>
+
+RUN yum -y update; yum clean all
+RUN yum -y install openssh-server passwd git wget make which gcc python-devel openssl openssl-devel; yum clean all
+ADD ./start.sh /start.sh
+RUN mkdir /var/run/sshd
+
+RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key -N '' 
+RUN ssh-keygen -t rsa -f /root/.ssh/id_rsa -N '' 
+
+RUN wget https://bootstrap.pypa.io/get-pip.py -P /tmp
+RUN chmod 755 /tmp/get-pip.py
+RUN python /tmp/get-pip.py
+RUN pip install virtualenv
+
+RUN ssh-keyscan bitbucket.org >> /root/.ssh/known_hosts
+
+RUN chmod 755 /start.sh
+RUN ./start.sh
+ENTRYPOINT ["/usr/sbin/sshd", "-D"]

--- a/jenkinsci/configure-jenkins-server.yml
+++ b/jenkinsci/configure-jenkins-server.yml
@@ -1,0 +1,19 @@
+---
+- name: Configure Jenkins server
+  hosts: jenkinsservers
+  vars:
+    jenkins_hostname: "{{inventory_hostname}}"
+    jenkins_package_state: latest
+    jenkins_admin_password: jenkins-password
+    jenkins_connection_retries: 5
+    jenkins_plugins: ['pipeline-model-declarative-agent', 'bouncycastle-api', 'branch-api', 'pipeline-build-step', 'external-monitor-job', 'credentials-binding', 'validating-string-parameter', 'pipeline-model-api', 'git', 'mercurial', 'conditional-buildstep', 'pipeline-input-step', 'pipeline-model-extensions', 'ant', 'javadoc', 'authentication-tokens', 'scm-api', 'pipeline-stage-tags-metadata', 'antisamy-markup-formatter', 'ws-cleanup', 'display-url-api', 'job-import-plugin', 'timestamper', 'ldap', 'gradle', 'email-ext', 'jquery', 'pipeline-stage-view', 'jquery-detached', 'workflow-aggregator', 'config-file-provider', 'token-macro', 'workflow-support', 'build-pipeline-plugin', 'parameterized-trigger', 'ssh-credentials', 'cloudbees-folder', 'docker-workflow', 'workflow-job', 'script-security', 'pam-auth', 'durable-task', 'structs', 'workflow-cps-global-lib', 'github-branch-source', 'build-timeout', 'jackson2-api', 'pipeline-rest-api', 'pipeline-github-lib', 'github-api', 'credentials', 'docker-commons', 'handlebars', 'resource-disposer', 'git-client', 'workflow-scm-step', 'workflow-api', 'pipeline-model-definition', 'git-server', 'matrix-auth', 'dashboard-view', 'workflow-cps', 'workflow-durable-task-step', 'plain-credentials', 'ssh-slaves', 'pipeline-graph-analysis', 'github', 'momentjs', 'run-condition', 'ssh', 'pipeline-milestone-step', 'github-organization-folder', 'junit', 'windows-slaves', 'workflow-basic-steps', 'docker-plugin', 'ace-editor', 'git-parameter', 'workflow-multibranch', 'bitbucket', 'icon-shim', 'workflow-step-api', 'matrix-project', 'maven-plugin', 'pipeline-stage-step', 'mailer']
+    jenkins_jobs: [{name: 'Deploy - CloudForms to Dev', config: "{{ lookup('file', './cloudforms_dev.xml') }}"}, {name: 'docker-pipeline', config: "{{ lookup('file', './docker_pipeline.xml') }}"}]
+    java_packages:
+      - java-1.8.0-openjdk
+  tasks:
+  - name: Install docker with yum
+    yum:
+      name: "docker"
+      state: present
+  roles:
+    - geerlingguy.jenkins

--- a/jenkinsci/jenkins-jobs/cloudforms_dev.xml
+++ b/jenkinsci/jenkins-jobs/cloudforms_dev.xml
@@ -1,0 +1,62 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description/>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterDefinition plugin="git-parameter@0.8.0">
+          <name>GIT_TAG</name>
+          <description/>
+          <uuid>af3f5a02-5381-4cec-bc1f-ddc872ab06f6</uuid>
+          <type>PT_TAG</type>
+          <branch/>
+          <tagFilter>*</tagFilter>
+          <branchFilter>.*/master</branchFilter>
+          <sortMode>DESCENDING_SMART</sortMode>
+          <defaultValue/>
+          <selectedValue>TOP</selectedValue>
+          <quickFilterEnabled>false</quickFilterEnabled>
+        </net.uaznia.lukanus.hudson.plugins.gitparameter.GitParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@3.1.0">
+    <configVersion>2</configVersion>
+    <userRemoteConfigs>
+      <hudson.plugins.git.UserRemoteConfig>
+        <url>https://bitbucket.org/encoretech/cloudforms.git</url>
+        <credentialsId></credentialsId>
+      </hudson.plugins.git.UserRemoteConfig>
+    </userRemoteConfigs>
+    <branches>
+      <hudson.plugins.git.BranchSpec>
+        <name>${GIT_TAG}</name>
+      </hudson.plugins.git.BranchSpec>
+    </branches>
+    <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+    <submoduleCfg class="list"/>
+    <extensions/>
+  </scm>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <authToken>deploy-dev</authToken>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>./bin/release.rb -c ./config/deployments/dev.yaml -r $GIT_TAG</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers/>
+  <buildWrappers>
+    <hudson.plugins.ws__cleanup.PreBuildCleanup plugin="ws-cleanup@0.32">
+      <deleteDirs>false</deleteDirs>
+      <cleanupParameter/>
+      <externalDelete/>
+    </hudson.plugins.ws__cleanup.PreBuildCleanup>
+  </buildWrappers>
+</project>

--- a/jenkinsci/jenkins-jobs/docker_pipeline.xml
+++ b/jenkinsci/jenkins-jobs/docker_pipeline.xml
@@ -1,0 +1,69 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<flow-definition plugin="workflow-job@2.13">
+  <actions/>
+  <description/>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>GIT_REPO</name>
+          <description/>
+          <defaultValue>git@bitbucket.org:encoretech/stackstorm.git</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>Server_Uri</name>
+          <description/>
+          <defaultValue>tcp://nor1devdoc01.dev.encore.tech/</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>Docker_Image</name>
+          <description/>
+          <defaultValue>jenkins-python</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>Docker_Build_Tag</name>
+          <description/>
+          <defaultValue>latest</defaultValue>
+        </hudson.model.StringParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+    <org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
+      <triggers/>
+    </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
+  </properties>
+  <definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition" plugin="workflow-cps@2.36">
+    <script>
+      node {
+          // Setup the Docker Registry (Docker Hub) + Credentials 
+          def registry_url = "${Server_Uri}" // Docker Hub
+          def build_tag = "${Docker_Build_Tag}" // default tag to push for to the registry
+          def container_name = "${Docker_Image}"
+        
+          stage("Connecting to Docker Server") {
+              echo "logging into ${registry_url}"
+
+              docker.withServer("${registry_url}") {
+                  stage("Building Container") {
+                      echo "Image ${container_name}"
+                      def container = docker.image("${container_name}:${build_tag}")
+                      container.withRun("--name=${container_name}") {
+                          stage("Checkout Repo") {
+                              //sh "docker exec -t ${container_name} git clone git@bitbucket.org:encoretech/stackstorm.git /root/git_project"
+                              sh "docker exec -t ${container_name} git clone ${GIT_REPO} /root/git_project"
+                          }
+                          stage("Running Make Tests") {
+                              sh "docker exec -t ${container_name} bash -c 'cd /root/git_project/; make'"
+                          }
+                      }
+                  }
+              }
+          }
+          currentBuild.result = 'SUCCESS'  
+      }
+    </script>
+    <sandbox>true</sandbox>
+  </definition>
+  <triggers/>
+  <disabled>false</disabled>
+</flow-definition>

--- a/jenkinsci/start.sh
+++ b/jenkinsci/start.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+__create_user() {
+# Create a user to SSH into as.
+USERNAME=jenkins
+useradd $USERNAME
+SSH_USERPASS=Password
+echo -e "$SSH_USERPASS\n$SSH_USERPASS" | (passwd --stdin $USERNAME)
+echo ssh $USERNAME password: $SSH_USERPASS
+}
+
+# Call all functions
+__create_user


### PR DESCRIPTION
Added Dockerfile for creating the proper docker image that has ssh installed and all neccessary python packages to do all of the needed testing. start.sh is called as a part of the Dockerfile to create a user and a password for ssh. Include the ansible playbook to configure jenkins on a blank instance. Also include the jobs that we use to run our test and deploy to cloudforms that are used in the playbook to create the jobs.